### PR TITLE
Revert "Bump express-validator from 5.3.1 to 6.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "colors": "^1.3.3",
     "cors": "^2.8.5",
     "express": "^4.16.4",
-    "express-validator": "^6.5.0",
+    "express-validator": "^5.3.1",
     "helmet": "^3.22.0",
     "highlight.js": "^9.14.2",
     "html-minifier": "^4.0.0",


### PR DESCRIPTION
Reverts gaon12/liberty-engine#3